### PR TITLE
CI: ansible-core devel drops support for Python 2.7 and 3.6

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -120,12 +120,12 @@ jobs:
         ansible:
           - devel
         python:
-          - '2.7'
-          - '3.6'
           - '3.7'
           - '3.8'
           - '3.9'
           - '3.10'
+          - '3.11'
+          - '3.12'
         include:
           # Ansible 2.9
           - ansible: stable-2.9


### PR DESCRIPTION
##### SUMMARY
Ref: https://github.com/ansible-collections/news-for-maintainers/issues/60

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
