### PR TITLE
Add MarkDown changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ See [Ansible Using collections](https://docs.ansible.com/ansible/latest/user_gui
 
 ## Release notes
 
-See [here](https://github.com/felixfontein/ansible-playground/tree/main/CHANGELOG.rst).
+See [here](https://github.com/felixfontein/ansible-playground/tree/main/CHANGELOG.md).
 
 ## More information
 

--- a/changelogs/config.yaml
+++ b/changelogs/config.yaml
@@ -7,6 +7,9 @@ keep_fragments: false
 mention_ancestor: true
 new_plugins_after_name: removed_features
 notesdir: fragments
+output_formats:
+- rst
+- md
 prelude_section_name: release_summary
 prelude_section_title: Release Summary
 sections:


### PR DESCRIPTION
##### SUMMARY
Now that antsibull-changelog allows to create a MarkDown changelog, let's use that. Also because GitHub screwed up RST rendering, and while it still works for this collection, who knows for how much longer...

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
changelog
